### PR TITLE
Improvements Part 4

### DIFF
--- a/ast.ml
+++ b/ast.ml
@@ -22,7 +22,10 @@ type expr =
   | Empty_Matrix of typ * expr * expr
   | Index_Expr of index_expr
   | Slice_Expr of slice_expr
-  | Binop of expr * op * expr
+  (* Bool is a flag indicating whether this is actually an update; i.e.
+   * an alias for something like a[0] += [[1, 2]]; mainly for memory cleaning
+   * purposes for matrix update operations *)
+  | Binop of expr * op * expr * bool
   | Unop of uop * expr
   | Assign of expr * expr
   | Call of expr * expr list
@@ -204,7 +207,7 @@ let rec string_of_expr expr =
   | Index_Expr e -> string_of_index_expr e
   | Slice_Expr e -> string_of_slice_expr e
   | Id s -> s
-  | Binop(e1, o, e2) ->
+  | Binop(e1, o, e2, _) ->
       string_of_expr e1 ^ " " ^ string_of_op o ^ " " ^ string_of_expr e2
   | Unop(o, e) -> string_of_uop o ^ string_of_expr e
   | Assign(e1, e2) -> string_of_expr e1 ^ " = " ^ string_of_expr e2

--- a/ast.ml
+++ b/ast.ml
@@ -217,12 +217,12 @@ let rec string_of_expr expr =
 
 let string_of_vdecl (kw, t, id, expr) =
   match kw, t, expr with
-  | (Nokw, _, Noexpr) -> string_of_typ t ^ " " ^ id
-  | (_, Exc, Noexpr) -> string_of_decl_kw kw ^ " " ^ id ^ ";\n"
-  | (_, Notyp, Noexpr) -> string_of_decl_kw kw ^ " " ^ id ^ ";\n"
-  | (_, _, Noexpr) -> string_of_decl_kw kw ^ " " ^ string_of_typ t ^ " " ^ id ^ ";\n"
-  | (_, Notyp, _) -> string_of_decl_kw kw ^ " " ^ id ^ ";\n"
-  | (_, _, _) -> string_of_decl_kw kw ^ " " ^ string_of_typ t ^ " " ^ id ^ " = " ^
+  | Nokw, _, Noexpr -> string_of_typ t ^ " " ^ id
+  | _, Exc, Noexpr -> string_of_decl_kw kw ^ " " ^ id ^ ";\n"
+  | _, Notyp, Noexpr -> string_of_decl_kw kw ^ " " ^ id ^ ";\n"
+  | _, _, Noexpr -> string_of_decl_kw kw ^ " " ^ string_of_typ t ^ " " ^ id ^ ";\n"
+  | _, Notyp, _ -> string_of_decl_kw kw ^ " " ^ id ^ ";\n"
+  | _ -> string_of_decl_kw kw ^ " " ^ string_of_typ t ^ " " ^ id ^ " = " ^
       string_of_expr expr ^ ";\n"
 
 let rec string_of_stmt = function

--- a/codegen.ml
+++ b/codegen.ml
@@ -1031,31 +1031,17 @@ let translate (env, program) =
             L.build_icmp L.Icmp.Eq e1' e2' "temp" builder
           (* Otherwise, it's a matrix result (either int or float) *)
           else
-            (* Wrap broadcasted scalars into temp 1x1 matrices; we'll free these
-             * immediately after computation; alternatively, if we're using
-             * expressions that return a new matrix and are unreachable
-             * after computation, free those *)
-            let e1', free_e1 =
-              if t1 == A.Int || t1 == A.Float then
-                (build_matrix_lit t1 [| [| e1' |] |] builder, true)
-              else
-                let free_e1 =
-                  match snd e1 with
-                  | SMatrix_Lit _ | SIndex_Expr _ | SSlice_Expr _ | SBinop(_, _, _) -> true
-                  | _ -> false
-                in
-                (e1', free_e1)
+            (* If we're using expressions that return a new matrix and
+             * are unreachable after computation, free those *)
+            let free_e1 =
+              match snd e1 with
+              | SMatrix_Lit _ | SIndex_Expr _ | SSlice_Expr _ | SBinop(_, _, _) -> true
+              | _ -> false
             in
-            let e2', free_e2 =
-              if t2 == A.Int || t2 == A.Float then
-                (build_matrix_lit t2 [| [| e2' |] |] builder, true)
-              else
-                let free_e2 =
-                  match snd e2 with
-                  | SMatrix_Lit _ | SIndex_Expr _ | SSlice_Expr _ | SBinop(_, _, _) -> true
-                  | _ -> false
-                in
-                (e2', free_e2)
+            let free_e2 =
+              match snd e2 with
+              | SMatrix_Lit _ | SIndex_Expr _ | SSlice_Expr _ | SBinop(_, _, _) -> true
+              | _ -> false
             in
             let res =
               match op with
@@ -1078,7 +1064,6 @@ let translate (env, program) =
                 ()
             in
             res
-
       | SUnop(op, e) ->
           let t, _ = e in
           let e' = expr scope builder e in

--- a/codegen.ml
+++ b/codegen.ml
@@ -779,7 +779,7 @@ let translate (env, program) =
           L.build_load cols_ptr "cols" builder
         in
         match (row_slice, col_slice) with
-        | (SSlice(i1, j1), SSlice(i2, j2)) ->
+        | SSlice(i1, j1), SSlice(i2, j2) ->
             let row_slice_ptr = L.build_alloca slice_t "row_slice_ptr" builder in
             let row_slice_start = L.build_struct_gep row_slice_ptr 0 "row_slice_start" builder in
             let row_slice_end = L.build_struct_gep row_slice_ptr 1 "row_slice_end" builder in
@@ -807,7 +807,7 @@ let translate (env, program) =
             let _ = L.build_store i2' col_slice_start builder in
             let _ = L.build_store j2' col_slice_end builder in
             (row_slice_ptr, col_slice_ptr)
-        | (_, _) -> make_err "internal error: build_dbl_slice given non-slice"
+        | _ -> make_err "internal error: build_dbl_slice given non-slice"
       in
 
       let sexpr_of_sindex = function

--- a/codegen.ml
+++ b/codegen.ml
@@ -152,65 +152,65 @@ let translate (env, program) =
       ("_delete_matrix", pointer_t matrix_t, [| pointer_t matrix_t; i32_t |]);
       ("_append_matrix", pointer_t matrix_t, [| pointer_t matrix_t; pointer_t matrix_t |]);
       (* Miscellaneous built-ins *)
-      ("length", i32_t, [| pointer_t array_t |]);
-      ("rows", i32_t, [| pointer_t matrix_t |]);
-      ("cols", i32_t, [| pointer_t matrix_t |]);
+      ("_length", i32_t, [| pointer_t array_t |]);
+      ("_rows", i32_t, [| pointer_t matrix_t |]);
+      ("_cols", i32_t, [| pointer_t matrix_t |]);
       ("_float_to_int", i32_t, [| float_t |]);
       ("_int_to_float", float_t, [| i32_t |]);
       ("_flip_matrix_type", pointer_t matrix_t, [| pointer_t matrix_t |]);
-      ("die", void_t, [| pointer_t i8_t |]);
+      ("_die", void_t, [| pointer_t i8_t |]);
     ]
   in
 
   let external_helper_types =
     List.fold_left add_external_func StringMap.empty [
       (* Pretty-printing functions *)
-      ("print_function", void_t, [| pointer_t i8_t |]);
+      ("_print_function", void_t, [| pointer_t i8_t |]);
       (
-        "print_array", void_t,
+        "_print_array", void_t,
         [|
           pointer_t array_t;
           pointer_t (L.function_type void_t [| pointer_t i8_t |])
         |]
       );
-      ("print_matrix", void_t, [| pointer_t matrix_t; i1_t |]);
+      ("_print_flat_matrix", void_t, [| pointer_t matrix_t |]);
       (* Array/matrix memory functions *)
       (
-        "deep_free_array", void_t,
+        "_deep_free_array", void_t,
         [|
           pointer_t array_t;
           pointer_t (L.function_type void_t [| pointer_t i8_t |])
         |]
       );
-      ("malloc_array", pointer_t array_t, [| i32_t; i64_t; i1_t |]);
-      ("malloc_matrix", pointer_t matrix_t, [| i32_t; i32_t; i32_t |]);
+      ("_malloc_array", pointer_t array_t, [| i32_t; i64_t; i1_t |]);
+      ("_malloc_matrix", pointer_t matrix_t, [| i32_t; i32_t; i32_t |]);
       (* Array index/slice functions *)
-      ("get_array", pointer_t i8_t, [| pointer_t array_t; i32_t |]);
-      ("set_array", void_t, [| pointer_t array_t; i32_t; pointer_t i8_t |]);
-      ("slice_array", pointer_t array_t, [| pointer_t array_t; pointer_t slice_t |]);
-      ("set_slice_array", void_t, [| pointer_t array_t; pointer_t slice_t; pointer_t array_t |]);
+      ("_get_array", pointer_t i8_t, [| pointer_t array_t; i32_t |]);
+      ("_set_array", void_t, [| pointer_t array_t; i32_t; pointer_t i8_t |]);
+      ("_slice_array", pointer_t array_t, [| pointer_t array_t; pointer_t slice_t |]);
+      ("_set_slice_array", void_t, [| pointer_t array_t; pointer_t slice_t; pointer_t array_t |]);
       (* Matrix index/slice functions *)
-      ("get_matrix", pointer_t i8_t, [| pointer_t matrix_t; i32_t; i32_t |]);
-      ("set_matrix", void_t, [| pointer_t matrix_t; i32_t; i32_t; pointer_t i8_t |]);
+      ("_get_matrix", pointer_t i8_t, [| pointer_t matrix_t; i32_t; i32_t |]);
+      ("_set_matrix", void_t, [| pointer_t matrix_t; i32_t; i32_t; pointer_t i8_t |]);
       (
-        "slice_matrix", pointer_t matrix_t,
+        "_slice_matrix", pointer_t matrix_t,
         [| pointer_t matrix_t; pointer_t slice_t; pointer_t slice_t |]
       );
       (
-        "set_slice_matrix", void_t,
+        "_set_slice_matrix", void_t,
         [| pointer_t matrix_t; pointer_t slice_t; pointer_t slice_t; pointer_t matrix_t |]
       );
-      ("insert_array", pointer_t array_t, [| pointer_t array_t; i32_t; pointer_t i8_t |]);
-      ("append_array", pointer_t array_t, [| pointer_t array_t; pointer_t i8_t |]);
+      ("_insert_array", pointer_t array_t, [| pointer_t array_t; i32_t; pointer_t i8_t |]);
+      ("_append_array", pointer_t array_t, [| pointer_t array_t; pointer_t i8_t |]);
       (* Binary operations *)
-      ("iexp", i32_t, [| i32_t; i32_t |]);
-      ("fexp", float_t, [| float_t; float_t |]);
-      ("matmult", pointer_t matrix_t, [| pointer_t matrix_t; pointer_t matrix_t |]);
-      ("mat_binop", pointer_t matrix_t, [| pointer_t matrix_t; i32_t; pointer_t matrix_t |]);
+      ("_iexp", i32_t, [| i32_t; i32_t |]);
+      ("_fexp", float_t, [| float_t; float_t |]);
+      ("_matmult", pointer_t matrix_t, [| pointer_t matrix_t; pointer_t matrix_t |]);
+      ("_mat_binop", pointer_t matrix_t, [| pointer_t matrix_t; i32_t; pointer_t matrix_t |]);
       (* Miscellaneous helper/built-ins *)
-      ("init_array", void_t, [| pointer_t array_t; pointer_t i8_t |]);
-      ("init_matrix", void_t, [| pointer_t matrix_t |]);
-      ("check", void_t, [| i1_t; pointer_t i8_t |]);
+      ("_init_array", void_t, [| pointer_t array_t; pointer_t i8_t |]);
+      ("_init_matrix", void_t, [| pointer_t matrix_t |]);
+      ("_check", void_t, [| i1_t; pointer_t i8_t |]);
       ("llvm.floor.f64", float_t, [| float_t |]);
     ]
   in
@@ -226,6 +226,7 @@ let translate (env, program) =
   in
 
   let call_helper fname args s builder =
+    (* TODO: remove this *)
     let _ = if not (StringMap.mem fname helper_funcs) then make_err fname in
     let helper_func = StringMap.find fname helper_funcs in
     L.build_call helper_func args s builder
@@ -284,18 +285,18 @@ let translate (env, program) =
           | A.Array t ->
               let element_fname = "_print_element_" ^ A.string_of_typ t in
               let _ =
-                call_helper "print_array"
+                call_helper "_print_array"
                 [| param; StringMap.find element_fname builtin_funcs |] "" builder
               in
               builtin_funcs
           | A.Matrix _ ->
               (* Print flat matrices if embedded within arrays *)
-              let _ = call_helper "print_matrix" [| param; L.const_int i1_t 1 |] "" builder in
+              let _ = call_helper "_print_flat_matrix" [| param |] "" builder in
               builtin_funcs
           | A.Func(_, _) ->
               (* Cast function pointer to "void pointer" *)
               let param = L.build_bitcast param (pointer_t i8_t) "param" builder in
-              let _ = call_helper "print_function" [| param |] "" builder in
+              let _ = call_helper "_print_function" [| param |] "" builder in
               builtin_funcs
           | A.BuiltInFunc ->
               make_err ("internal error: BuiltInFunc should have not made it " ^
@@ -323,7 +324,7 @@ let translate (env, program) =
       let builtin_funcs = build_print_element_func array_type builtin_funcs in
       let print_element_func = StringMap.find element_fname builtin_funcs in
       let _ =
-        call_helper "print_array"
+        call_helper "_print_array"
         [| param; print_element_func |] "" builder
       in
       let _ = L.build_ret_void builder in
@@ -342,7 +343,7 @@ let translate (env, program) =
 
       (* Cast function pointer to "void pointer" *)
       let param = L.build_bitcast param (pointer_t i8_t) "param" builder in
-      let _ = call_helper "print_function" [| param |] "" builder in
+      let _ = call_helper "_print_function" [| param |] "" builder in
       let _ = L.build_ret_void builder in
       StringMap.add fname print_func builtin_funcs
     in
@@ -404,7 +405,7 @@ let translate (env, program) =
               let element_fname = "_free_element_" ^ A.string_of_typ t in
               let free_element_func = StringMap.find element_fname builtin_funcs in
               let _ =
-                call_helper "deep_free_array"
+                call_helper "_deep_free_array"
                 [| param; free_element_func |] "" builder
               in
               builtin_funcs
@@ -438,7 +439,7 @@ let translate (env, program) =
       let builtin_funcs = build_free_element_func array_type builtin_funcs in
       let free_element_func = StringMap.find element_fname builtin_funcs in
       let _ =
-        call_helper "deep_free_array"
+        call_helper "_deep_free_array"
         [| param; free_element_func |] "" builder
       in
       let _ = L.build_ret_void builder in
@@ -466,7 +467,7 @@ let translate (env, program) =
       let _ = Array.set params 2 element_ptr in
 
       (* Call insert_array *)
-      let res = call_helper "insert_array" params "res" builder in
+      let res = call_helper "_insert_array" params "res" builder in
       let _ = L.build_ret res builder in
       StringMap.add fname insert_func builtin_funcs
     in
@@ -492,7 +493,7 @@ let translate (env, program) =
       let _ = Array.set params 1 element_ptr in
 
       (* Call append_array *)
-      let res = call_helper "append_array" params "res" builder in
+      let res = call_helper "_append_array" params "res" builder in
       let _ = L.build_ret res builder in
       StringMap.add fname append_func builtin_funcs
     in
@@ -558,7 +559,7 @@ let translate (env, program) =
           | _ -> make_err ("internal error: " ^ fname ^ " is invalid append")
         )
       | ["length"; _] | ["rows"; _] | ["cols"; _] | ["die"; _] ->
-          build_external_builtin ~alias:(Some fname) (List.hd fname_fragments) builtin_funcs
+          build_external_builtin ~alias:(Some fname) ("_" ^ List.hd fname_fragments) builtin_funcs
       | ["to"; "int"; arg_type] | ["to"; "float"; arg_type] ->
           let arg_type = A.typ_of_string arg_type in
           (
@@ -610,7 +611,7 @@ let translate (env, program) =
   (* Builds a runtime check on a condition; if condition is not true,
    * then program prints error to stderr and exits with return code EXIT_FAILURE *)
   let build_check cond err builder =
-    let _ = call_helper "check" [| cond; err |] "" builder in
+    let _ = call_helper "_check" [| cond; err |] "" builder in
     ()
   in
 
@@ -693,7 +694,7 @@ let translate (env, program) =
         let ltype = ltype_of_typ typ in
         let length = L.const_int i32_t (Array.length raw_elements) in
         let arr_ptr =
-          call_helper "malloc_array"
+          call_helper "_malloc_array"
           [| length; L.size_of ltype; array_has_ptrs typ |] "arr_ptr" builder
         in
 
@@ -704,7 +705,7 @@ let translate (env, program) =
           (* Cast element pointer to "void pointer" *)
           let element_ptr = L.build_bitcast element_ptr (pointer_t i8_t) "element_ptr" builder in
           let _ =
-            call_helper "set_array"
+            call_helper "_set_array"
             [| arr_ptr; L.const_int i32_t i; element_ptr |] "" builder
           in
           ()
@@ -725,7 +726,7 @@ let translate (env, program) =
         let cols = L.const_int i32_t (Array.length raw_elements.(0)) in
         let mat_type = mat_type_of_typ typ in
         let mat_ptr =
-          call_helper "malloc_matrix" [| rows; cols; mat_type |] "mat_ptr" builder
+          call_helper "_malloc_matrix" [| rows; cols; mat_type |] "mat_ptr" builder
         in
 
         (* Allocate and fill matrix body *)
@@ -736,7 +737,7 @@ let translate (env, program) =
             (* Cast element pointer to "void pointer" *)
             let element_ptr = L.build_bitcast element_ptr (pointer_t i8_t) "element_ptr" builder in
             let _ =
-              call_helper "set_matrix"
+              call_helper "_set_matrix"
               [| mat_ptr; L.const_int i32_t i; L.const_int i32_t j; element_ptr |] "" builder
             in
             ()
@@ -852,13 +853,13 @@ let translate (env, program) =
           let ltype = ltype_of_typ t in
           let length = expr scope builder n in
           let arr_ptr =
-            call_helper "malloc_array"
+            call_helper "_malloc_array"
             [| length; L.size_of ltype; array_has_ptrs t |] "arr_ptr" builder
           in
           let init_ptr = L.build_alloca ltype "init_ptr" builder in
           let _ = L.build_store (init t) init_ptr builder in
           let init_ptr = L.build_bitcast init_ptr (pointer_t i8_t) "init_ptr" builder in
-          let _ = call_helper "init_array" [| arr_ptr; init_ptr |] "" builder in
+          let _ = call_helper "_init_array" [| arr_ptr; init_ptr |] "" builder in
           arr_ptr
       | SMatrix_Lit l ->
           let raw_elements = Array.map (Array.map (expr scope builder)) l in
@@ -868,10 +869,10 @@ let translate (env, program) =
           let rows = expr scope builder r in
           let cols = expr scope builder c in
           let mat_ptr =
-            call_helper "malloc_matrix"
+            call_helper "_malloc_matrix"
             [| rows; cols; mat_type_of_typ t |] "mat_ptr" builder
           in
-          let _ = call_helper "init_matrix" [| mat_ptr |] "" builder in
+          let _ = call_helper "_init_matrix" [| mat_ptr |] "" builder in
           mat_ptr
       | SIndex_Expr i ->
           (
@@ -880,7 +881,7 @@ let translate (env, program) =
                 let ltype = ltype_of_typ t in
                 let e' = expr scope builder e in
                 let i' = expr scope builder (sexpr_of_sindex i) in
-                let ptr = call_helper "get_array" [| e'; i' |] "ptr" builder in
+                let ptr = call_helper "_get_array" [| e'; i' |] "ptr" builder in
                 let ptr = L.build_bitcast ptr (pointer_t ltype) "ptr" builder in
                 L.build_load ptr "arr_element" builder
             | SDbl_Index(e, i, j) ->
@@ -889,7 +890,7 @@ let translate (env, program) =
                 let i' = expr scope builder (sexpr_of_sindex i) in
                 let j' = expr scope builder (sexpr_of_sindex j) in
                 let ptr =
-                  call_helper "get_matrix" [| e'; i'; j' |] "mat_element" builder
+                  call_helper "_get_matrix" [| e'; i'; j' |] "mat_element" builder
                 in
                 let ptr = L.build_bitcast ptr (pointer_t ltype) "ptr" builder in
                 L.build_load ptr "mat_element" builder
@@ -900,11 +901,11 @@ let translate (env, program) =
             | SSgl_Slice(e, s) ->
                 let e' = expr scope builder e in
                 let s' = build_sgl_slice e' s builder in
-                call_helper "slice_array" [| e'; s' |] "arr_slice" builder
+                call_helper "_slice_array" [| e'; s' |] "arr_slice" builder
             | SDbl_Slice(e, s1, s2) ->
                 let e' = expr scope builder e in
                 let s1', s2' = build_dbl_slice e' s1 s2 builder in
-                call_helper "slice_matrix" [| e'; s1'; s2' |] "mat_slice" builder
+                call_helper "_slice_matrix" [| e'; s1'; s2' |] "mat_slice" builder
           )
       | SNoexpr -> init t
       | SId s ->
@@ -935,7 +936,7 @@ let translate (env, program) =
                       let ptr = L.build_alloca ltype "ptr" builder in
                       let _ = L.build_store e2' ptr builder in
                       let ptr = L.build_bitcast ptr (pointer_t i8_t) "ptr" builder in
-                      let _ = call_helper "set_array" [| e'; i'; ptr |] "" builder in
+                      let _ = call_helper "_set_array" [| e'; i'; ptr |] "" builder in
                       ()
                   | SDbl_Index(e, i, j) ->
                       let ltype = ltype_of_typ t in
@@ -946,7 +947,7 @@ let translate (env, program) =
                       let _ = L.build_store e2' ptr builder in
                       let ptr = L.build_bitcast ptr (pointer_t i8_t) "ptr" builder in
                       let _ =
-                        call_helper "set_matrix"
+                        call_helper "_set_matrix"
                         [| e'; i'; j'; ptr |] "" builder
                       in
                       ()
@@ -958,7 +959,7 @@ let translate (env, program) =
                     let e' = expr scope builder e in
                     let s' = build_sgl_slice e' s builder in
                     let _ =
-                      call_helper "set_slice_array"
+                      call_helper "_set_slice_array"
                       [| e'; s'; e2' |] "" builder
                     in
                     ()
@@ -966,7 +967,7 @@ let translate (env, program) =
                     let e' = expr scope builder e in
                     let s1', s2' = build_dbl_slice e' s1 s2 builder in
                     let _ =
-                      call_helper "set_slice_matrix"
+                      call_helper "_set_slice_matrix"
                       [| e'; s1'; s2'; e2' |] "" builder
                     in
                     ()
@@ -991,7 +992,7 @@ let translate (env, program) =
             | A.Mult -> L.build_fmul e1' e2' "temp" builder
             | A.Div -> L.build_fdiv e1' e2' "temp" builder
             | A.Mod -> L.build_frem e1' e2' "temp" builder
-            | A.Exp -> call_helper "fexp" [| e1'; e2'|] "temp" builder
+            | A.Exp -> call_helper "_fexp" [| e1'; e2'|] "temp" builder
             | A.Equal -> L.build_fcmp L.Fcmp.Oeq e1' e2' "temp" builder
             | A.Neq -> L.build_fcmp L.Fcmp.One e1' e2' "temp" builder
             | A.Less -> L.build_fcmp L.Fcmp.Olt e1' e2' "temp" builder
@@ -1009,7 +1010,7 @@ let translate (env, program) =
             | A.Mult -> L.build_mul e1' e2' "temp" builder
             | A.Div -> L.build_sdiv e1' e2' "temp" builder
             | A.Mod -> L.build_srem e1' e2' "temp" builder
-            | A.Exp -> call_helper "iexp" [| e1'; e2'|] "temp" builder
+            | A.Exp -> call_helper "_iexp" [| e1'; e2'|] "temp" builder
             | A.Equal -> L.build_icmp L.Icmp.Eq e1' e2' "temp" builder
             | A.Neq -> L.build_icmp L.Icmp.Ne e1' e2' "temp" builder
             | A.Less -> L.build_icmp L.Icmp.Slt e1' e2' "temp" builder
@@ -1058,11 +1059,11 @@ let translate (env, program) =
             in
             let res =
               match op with
-              | A.MatMult -> call_helper "matmult" [| e1'; e2' |] "temp" builder
+              | A.MatMult -> call_helper "_matmult" [| e1'; e2' |] "temp" builder
               | A.And | A.Or -> make_err err
               | _ ->
                   let opcode = L.const_int i32_t (get_mat_opcode op) in
-                  call_helper "mat_binop" [| e1'; opcode; e2' |] "temp"  builder
+                  call_helper "_mat_binop" [| e1'; opcode; e2' |] "temp"  builder
             in
             let _ =
               if free_e1 then

--- a/native.c
+++ b/native.c
@@ -43,32 +43,32 @@ static int min(const int a, const int b) {
 }
 
 /* Runtime error-checking functions */
-void die(const char* err) {
+void _die(const char* err) {
     fprintf(stderr, "%s\n", err);
     exit(EXIT_FAILURE);
 }
 
-void check(const bool cond, const char* err) {
+void _check(const bool cond, const char* err) {
     if (!cond) {
-        die(err);
+        _die(err);
     }
 }
 
 static void check_arr_index(const array_t* arr, const int i) {
-    check(i >= 0 && i < arr->length, ARR_IDX_ERR);
+    _check(i >= 0 && i < arr->length, ARR_IDX_ERR);
 }
 
 static void check_arr_slice(const array_t* arr, const slice_t* slice) {
     int start = slice->start;
     int end = slice->end;
-    check(start < end, SLICE_ERR);
+    _check(start < end, SLICE_ERR);
     check_arr_index(arr, start);
-    check(end <= arr->length, ARR_IDX_ERR);
+    _check(end <= arr->length, ARR_IDX_ERR);
 }
 
 static void check_mat_index(const matrix_t* mat, const int i, const int j) {
-    check(i >= 0 && i < mat->rows, MAT_IDX_ERR);
-    check(j >= 0 && j < mat->cols, MAT_IDX_ERR);
+    _check(i >= 0 && i < mat->rows, MAT_IDX_ERR);
+    _check(j >= 0 && j < mat->cols, MAT_IDX_ERR);
 }
 
 static void check_mat_slice(const matrix_t* mat, const slice_t* row_slice, const slice_t* col_slice) {
@@ -76,16 +76,16 @@ static void check_mat_slice(const matrix_t* mat, const slice_t* row_slice, const
     int end_i = row_slice->end;
     int start_j = col_slice->start;
     int end_j = col_slice->end;
-    check(start_i < end_i, SLICE_ERR);
-    check(start_j < end_j, SLICE_ERR);
+    _check(start_i < end_i, SLICE_ERR);
+    _check(start_j < end_j, SLICE_ERR);
     check_mat_index(mat, start_i, start_j);
-    check(end_i <= mat->rows, MAT_IDX_ERR);
-    check(end_j <= mat->cols, MAT_IDX_ERR);
+    _check(end_i <= mat->rows, MAT_IDX_ERR);
+    _check(end_j <= mat->cols, MAT_IDX_ERR);
 }
 
 static void check_row_dims(const matrix_t* mat, const matrix_t* row) {
-    check(row->rows == 1, ROW_DIM_ERR);
-    check(row->cols == mat->cols, ROW_DIM_ERR);
+    _check(row->rows == 1, ROW_DIM_ERR);
+    _check(row->cols == mat->cols, ROW_DIM_ERR);
 }
 
 static void check_mat_binop_dims(const matrix_t* a, const matrix_t* b) {
@@ -93,8 +93,8 @@ static void check_mat_binop_dims(const matrix_t* a, const matrix_t* b) {
     int rows_b = b->rows;
     int cols_a = a->cols;
     int cols_b = b->cols;
-    check(rows_a == rows_b || min(rows_a, rows_b) == 1, MAT_BINOP_ERR);
-    check(cols_a == cols_b || min(cols_a, cols_b) == 1, MAT_BINOP_ERR);
+    _check(rows_a == rows_b || min(rows_a, rows_b) == 1, MAT_BINOP_ERR);
+    _check(cols_a == cols_b || min(cols_a, cols_b) == 1, MAT_BINOP_ERR);
 }
 
 /* Pretty-printing functions */
@@ -118,15 +118,7 @@ void _print_string(const char* s) {
     printf("%s", s);
 }
 
-void _print_matrix(const matrix_t* m) {
-    print_matrix(m, false);
-}
-
-void print_function(const void* p) {
-    printf("function at %p", p);
-}
-
-void print_matrix(const matrix_t* mat, const bool flat) {
+static void print_matrix(const matrix_t* mat, const bool flat) {
     printf("[");
     int rows = mat->rows;
     int cols = mat->cols;
@@ -164,11 +156,23 @@ void print_matrix(const matrix_t* mat, const bool flat) {
     printf("]");
 }
 
-void print_array(const array_t* arr, void(*const print_element)(const void*)) {
+void _print_matrix(const matrix_t* m) {
+    print_matrix(m, false);
+}
+
+void _print_flat_matrix(const matrix_t* m) {
+    print_matrix(m, true);
+}
+
+void _print_function(const void* p) {
+    printf("function at %p", p);
+}
+
+void _print_array(const array_t* arr, void(*const print_element)(const void*)) {
     int length = arr->length;
     printf("{|");
     for (int i = 0; i < length; i++) {
-        print_element(get_array(arr, i));
+        print_element(_get_array(arr, i));
         if (i != length - 1) {
             printf(", ");
         }
@@ -196,11 +200,11 @@ void _free_array(array_t* arr) {
     free(arr);
 }
 
-void deep_free_array(array_t* arr, void(*const free_element)(void*)) {
+void _deep_free_array(array_t* arr, void(*const free_element)(void*)) {
     int length = arr->length;
 
     for (int i = 0; i < length; i++) {
-        free_element(get_array(arr, i));
+        free_element(_get_array(arr, i));
     }
 
     _free_array(arr);
@@ -229,8 +233,8 @@ static void set_ptrs_array(array_t* arr, const void* body) {
     }
 }
 
-array_t* malloc_array(const int length, const size_t size, const bool has_ptrs) {
-    check(length > 0, ARR_LEN_ERR);
+array_t* _malloc_array(const int length, const size_t size, const bool has_ptrs) {
+    _check(length > 0, ARR_LEN_ERR);
     array_t* arr = malloc(sizeof(array_t));
     arr->body = malloc(length * sizeof(void*));
     arr->length = length;
@@ -243,9 +247,9 @@ array_t* malloc_array(const int length, const size_t size, const bool has_ptrs) 
     return arr;
 }
 
-matrix_t* malloc_matrix(const int rows, const int cols, const enum mat_type type) {
-    check(rows > 0, MAT_ROWS_ERR);
-    check(cols > 0, MAT_COLS_ERR);
+matrix_t* _malloc_matrix(const int rows, const int cols, const enum mat_type type) {
+    _check(rows > 0, MAT_ROWS_ERR);
+    _check(cols > 0, MAT_COLS_ERR);
     matrix_t* mat = malloc(sizeof(matrix_t));
     mat->rows = rows;
     mat->cols = cols;
@@ -271,55 +275,55 @@ matrix_t* malloc_matrix(const int rows, const int cols, const enum mat_type type
 }
 
 /* Array index/slice functions */
-void* get_array(const array_t* arr, const int i) {
+void* _get_array(const array_t* arr, const int i) {
     check_arr_index(arr, i);
     if (arr->has_ptrs) {
-        check(*(void**)arr->body[i] != NULL, NULL_VALUE_ERR);
+        _check(*(void**)arr->body[i] != NULL, NULL_VALUE_ERR);
     }
     return arr->body[i];
 }
 
-void set_array(array_t* arr, const int i, const void* data) {
+void _set_array(array_t* arr, const int i, const void* data) {
     check_arr_index(arr, i);
     /* Perform a shallow copy */
     memcpy(arr->body[i], data, arr->size);
 }
 
-array_t* slice_array(const array_t* arr, const slice_t* slice) {
+array_t* _slice_array(const array_t* arr, const slice_t* slice) {
     check_arr_slice(arr, slice);
     int start_i = slice->start;
     int end_i = slice->end;
     int length = end_i - start_i;
-    array_t* res = malloc_array(length, arr->size, arr->has_ptrs);
+    array_t* res = _malloc_array(length, arr->size, arr->has_ptrs);
 
     for (int i = 0; i < length; i++) {
-        set_array(res, i, get_array(arr, i + start_i));
+        _set_array(res, i, _get_array(arr, i + start_i));
     }
 
     return res;
 }
 
-void set_slice_array(array_t* arr, const slice_t* slice, const array_t* data) {
+void _set_slice_array(array_t* arr, const slice_t* slice, const array_t* data) {
     check_arr_slice(arr, slice);
     int start_i = slice->start;
     int end_i = slice->end;
     for (int i = start_i; i < end_i; i++) {
-        set_array(arr, i, data->body[i - start_i]);
+        _set_array(arr, i, data->body[i - start_i]);
     }
 }
 
-array_t* insert_array(const array_t* arr, const int pos_i, const void* data) {
+array_t* _insert_array(const array_t* arr, const int pos_i, const void* data) {
     check_arr_index(arr, pos_i);
     int length = arr->length + 1;
-    array_t* res = malloc_array(length, arr->size, arr->has_ptrs);
+    array_t* res = _malloc_array(length, arr->size, arr->has_ptrs);
 
     for (int i = 0; i < length; i++) {
         if (i < pos_i) {
-            set_array(res, i, arr->body[i]);
+            _set_array(res, i, arr->body[i]);
         } else if (i == pos_i) {
-            set_array(res, i, data);
+            _set_array(res, i, data);
         } else {
-            set_array(res, i, arr->body[i - 1]);
+            _set_array(res, i, arr->body[i - 1]);
         }
     }
 
@@ -329,28 +333,28 @@ array_t* insert_array(const array_t* arr, const int pos_i, const void* data) {
 array_t* _delete_array(const array_t* arr, const int pos_i) {
     check_arr_index(arr, pos_i);
     int length = arr->length - 1;
-    array_t* res = malloc_array(length, arr->size, arr->has_ptrs);
+    array_t* res = _malloc_array(length, arr->size, arr->has_ptrs);
 
     for (int i = 0; i < length; i++) {
         if (i < pos_i) {
-            set_array(res, i, arr->body[i]);
+            _set_array(res, i, arr->body[i]);
         } else {
-            set_array(res, i, arr->body[i + 1]);
+            _set_array(res, i, arr->body[i + 1]);
         }
     }
 
     return res;
 }
 
-array_t* append_array(const array_t* arr, const void* data) {
+array_t* _append_array(const array_t* arr, const void* data) {
     int length = arr->length + 1;
-    array_t* res = malloc_array(length, arr->size, arr->has_ptrs);
+    array_t* res = _malloc_array(length, arr->size, arr->has_ptrs);
 
     for (int i = 0; i < length; i++) {
         if (i == length - 1) {
-            set_array(res, i, data);
+            _set_array(res, i, data);
         } else {
-            set_array(res, i, arr->body[i]);
+            _set_array(res, i, arr->body[i]);
         }
     }
 
@@ -358,7 +362,7 @@ array_t* append_array(const array_t* arr, const void* data) {
 }
 
 /* Matrix index/slice functions */
-void* get_matrix(const matrix_t* mat, const int i, const int j) {
+void* _get_matrix(const matrix_t* mat, const int i, const int j) {
     check_mat_index(mat, i, j);
     switch (mat->type) {
         case Int: return (void*)&mat->body.ibody[i][j];
@@ -373,7 +377,7 @@ void* get_matrix(const matrix_t* mat, const int i, const int j) {
     exit(EXIT_FAILURE);
 }
 
-void set_matrix(matrix_t* mat, const int i, const int j, const void* data) {
+void _set_matrix(matrix_t* mat, const int i, const int j, const void* data) {
     check_mat_index(mat, i, j);
     switch (mat->type) {
         case Int: mat->body.ibody[i][j] = *(int*)data; break;
@@ -381,7 +385,7 @@ void set_matrix(matrix_t* mat, const int i, const int j, const void* data) {
     }
 }
 
-matrix_t* slice_matrix(const matrix_t* mat, const slice_t* row_slice,
+matrix_t* _slice_matrix(const matrix_t* mat, const slice_t* row_slice,
                        const slice_t* col_slice) {
     check_mat_slice(mat, row_slice, col_slice);
     int start_i = row_slice->start;
@@ -392,7 +396,7 @@ matrix_t* slice_matrix(const matrix_t* mat, const slice_t* row_slice,
     int rows = end_i - start_i;
     int cols = end_j - start_j;
     enum mat_type type = mat->type;
-    matrix_t* res = malloc_matrix(rows, cols, type);
+    matrix_t* res = _malloc_matrix(rows, cols, type);
 
     for (int i = 0; i < rows; i++) {
         for (int j = 0; j < cols; j++) {
@@ -410,7 +414,7 @@ matrix_t* slice_matrix(const matrix_t* mat, const slice_t* row_slice,
     return res;
 }
 
-void set_slice_matrix(matrix_t* mat, const slice_t* row_slice,
+void _set_slice_matrix(matrix_t* mat, const slice_t* row_slice,
                       const slice_t* col_slice, const matrix_t* data) {
     check_mat_slice(mat, row_slice, col_slice);
     int start_i = row_slice->start;
@@ -437,7 +441,7 @@ matrix_t* _insert_matrix(const matrix_t* mat, const int row_i, const matrix_t* r
     int rows = mat->rows + 1;
     int cols = mat->cols;
     enum mat_type type = mat->type;
-    matrix_t* res = malloc_matrix(rows, cols, type);
+    matrix_t* res = _malloc_matrix(rows, cols, type);
 
     for (int i = 0; i < rows; i++) {
         for (int j = 0; j < cols; j++) {
@@ -468,7 +472,7 @@ matrix_t* _delete_matrix(const matrix_t* mat, const int row_i) {
     int rows = mat->rows - 1;
     int cols = mat->cols;
     enum mat_type type = mat->type;
-    matrix_t* res = malloc_matrix(rows, cols, type);
+    matrix_t* res = _malloc_matrix(rows, cols, type);
 
     for (int i = 0; i < rows; i++) {
         for (int j = 0; j < cols; j++) {
@@ -494,7 +498,7 @@ matrix_t* _append_matrix(const matrix_t* mat, const matrix_t* row) {
     int rows = mat->rows + 1;
     int cols = mat->cols;
     enum mat_type type = mat->type;
-    matrix_t* res = malloc_matrix(rows, cols, type);
+    matrix_t* res = _malloc_matrix(rows, cols, type);
 
     for (int i = 0; i < rows; i++) {
         for (int j = 0; j < cols; j++) {
@@ -516,20 +520,20 @@ matrix_t* _append_matrix(const matrix_t* mat, const matrix_t* row) {
 }
 
 /* Binary operations */
-int iexp(const int a, const int b){
+int _iexp(const int a, const int b){
     return (int) pow((double) a, (double) b);
 }
 
-double fexp(const double a, const double b){
+double _fexp(const double a, const double b){
     return pow(a, b);
 }
 
-matrix_t* matmult(const matrix_t* a, const matrix_t* b){
-    check(a->cols == b->rows, MAT_MULT_ERR);
+matrix_t* _matmult(const matrix_t* a, const matrix_t* b){
+    _check(a->cols == b->rows, MAT_MULT_ERR);
     int rows = a->rows;
     int cols = b->cols;
     enum mat_type type = a->type;
-    matrix_t* res = malloc_matrix(rows, cols, type);
+    matrix_t* res = _malloc_matrix(rows, cols, type);
 
     for (int i = 0; i < rows; i++){
         for (int j = 0; j < cols; j++){
@@ -553,12 +557,12 @@ matrix_t* matmult(const matrix_t* a, const matrix_t* b){
     return res;
 }
 
-matrix_t* mat_binop(const matrix_t* a, const enum mat_op op, const matrix_t* b) {
+matrix_t* _mat_binop(const matrix_t* a, const enum mat_op op, const matrix_t* b) {
     check_mat_binop_dims(a, b);
     int rows = max(a->rows, b->rows);
     int cols = max(a->cols, b->cols);
     enum mat_type type = a->type;
-    matrix_t* res = malloc_matrix(rows, cols, type);
+    matrix_t* res = _malloc_matrix(rows, cols, type);
 
     for (int i = 0; i < rows; i++) {
         for (int j = 0; j < cols; j++) {
@@ -576,19 +580,19 @@ matrix_t* mat_binop(const matrix_t* a, const enum mat_op op, const matrix_t* b) 
                         case Sub: r_body[i][j] = a_ij - b_ij; break;
                         case Mult: r_body[i][j] = a_ij * b_ij; break;
                         case Div:
-                            check(b_ij != 0, DIV_ZERO_ERR);
+                            _check(b_ij != 0, DIV_ZERO_ERR);
                             r_body[i][j] = a_ij / b_ij;
                             break;
                         case Mod:
-                            check(b_ij != 0, DIV_ZERO_ERR);
+                            _check(b_ij != 0, DIV_ZERO_ERR);
                             r_body[i][j] = a_ij % b_ij;
                             break;
                         case Exp:
-                            check(a_ij != 0 || b_ij >= 0, EXP_ZERO_ERR);
+                            _check(a_ij != 0 || b_ij >= 0, EXP_ZERO_ERR);
                             /* No need to perform check for negative base
                              * raised to non-integer exponent; the exponents
                              * here are inherently integers already */
-                            r_body[i][j] = iexp(a_ij, b_ij);
+                            r_body[i][j] = _iexp(a_ij, b_ij);
                             break;
                         case Equal: r_body[i][j] = a_ij == b_ij; break;
                         case Neq: r_body[i][j] = a_ij != b_ij; break;
@@ -608,17 +612,17 @@ matrix_t* mat_binop(const matrix_t* a, const enum mat_op op, const matrix_t* b) 
                         case Sub: r_body[i][j] = a_ij - b_ij; break;
                         case Mult: r_body[i][j] = a_ij * b_ij; break;
                         case Div:
-                            check(b_ij != 0., DIV_ZERO_ERR);
+                            _check(b_ij != 0., DIV_ZERO_ERR);
                             r_body[i][j] = a_ij / b_ij;
                             break;
                         case Mod:
-                            check(b_ij != 0., DIV_ZERO_ERR);
+                            _check(b_ij != 0., DIV_ZERO_ERR);
                             r_body[i][j] = fmod(a_ij, b_ij);
                             break;
                         case Exp:
-                            check(a_ij != 0. || b_ij >= 0, EXP_ZERO_ERR);
-                            check(a_ij >= 0. || floor(b_ij) == b_ij, EXP_NEG_ERR);
-                            r_body[i][j] = fexp(a_ij, b_ij);
+                            _check(a_ij != 0. || b_ij >= 0, EXP_ZERO_ERR);
+                            _check(a_ij >= 0. || floor(b_ij) == b_ij, EXP_NEG_ERR);
+                            r_body[i][j] = _fexp(a_ij, b_ij);
                             break;
                         case Equal: r_body[i][j] = (a_ij == b_ij) ? 1. : 0.; break;
                         case Neq: r_body[i][j] = (a_ij != b_ij) ? 1. : 0.; break;
@@ -637,14 +641,14 @@ matrix_t* mat_binop(const matrix_t* a, const enum mat_op op, const matrix_t* b) 
 }
 
 /* Miscellaneous helpers/built-ins */
-void init_array(array_t* arr, const void* data) {
+void _init_array(array_t* arr, const void* data) {
     int length = arr->length;
     for (int i = 0; i < length; i++) {
-        set_array(arr, i, data);
+        _set_array(arr, i, data);
     }
 }
 
-void init_matrix(matrix_t* mat) {
+void _init_matrix(matrix_t* mat) {
     int rows = mat->rows;
     int cols = mat->cols;
     for (int i = 0; i < rows; i++) {
@@ -657,15 +661,15 @@ void init_matrix(matrix_t* mat) {
     }
 }
 
-int length(const array_t* arr) {
+int _length(const array_t* arr) {
     return arr->length;
 }
 
-int rows(const matrix_t* mat) {
+int _rows(const matrix_t* mat) {
     return mat->rows;
 }
 
-int cols(const matrix_t* mat) {
+int _cols(const matrix_t* mat) {
     return mat->cols;
 }
 
@@ -682,7 +686,7 @@ matrix_t* _flip_matrix_type(const matrix_t* mat) {
     int cols = mat->cols;
     /* Flip the type */
     enum mat_type type = 1 - mat->type;
-    matrix_t* res = malloc_matrix(rows, cols, type);
+    matrix_t* res = _malloc_matrix(rows, cols, type);
 
     for (int i = 0; i < rows; i++) {
         for (int j = 0; j < cols; j++) {

--- a/native.h
+++ b/native.h
@@ -37,56 +37,56 @@ void _print_int(const int);
 void _print_float(const double);
 void _print_string(const char*);
 void _print_matrix(const matrix_t*);
-void print_function(const void*);
-void print_matrix(const matrix_t*, const bool);
+void _print_flat_matrix(const matrix_t*);
+void _print_function(const void*);
 /**
  * Second argument should be a function that prints out
  * an element of the array; therefore, it should be able
  * to perform the correct cast at some point in its
  * execution (print_array does not handle this and is type-agnostic)
  */
-void print_array(const array_t*, void(*const)(const void*));
+void _print_array(const array_t*, void(*const)(const void*));
 
 /* Array/matrix memory functions */
 void _free_matrix(matrix_t*);
 void _free_array(array_t*);
 /* Same as print_array for the second argument, but to free an element */
-void deep_free_array(array_t*, void(*const)(void*));
-array_t* malloc_array(const int, const size_t, const bool);
-matrix_t* malloc_matrix(const int, const int, const enum mat_type);
+void _deep_free_array(array_t*, void(*const)(void*));
+array_t* _malloc_array(const int, const size_t, const bool);
+matrix_t* _malloc_matrix(const int, const int, const enum mat_type);
 
 /* Array index/slice functions */
-void* get_array(const array_t*, const int);
-void set_array(array_t*, const int, const void*);
-array_t* slice_array(const array_t*, const slice_t*);
-void set_slice_array(array_t*, const slice_t*, const array_t*);
-array_t* insert_array(const array_t*, const int, const void*);
+void* _get_array(const array_t*, const int);
+void _set_array(array_t*, const int, const void*);
+array_t* _slice_array(const array_t*, const slice_t*);
+void _set_slice_array(array_t*, const slice_t*, const array_t*);
+array_t* _insert_array(const array_t*, const int, const void*);
 array_t* _delete_array(const array_t*, const int);
-array_t* append_array(const array_t*, const void*);
+array_t* _append_array(const array_t*, const void*);
 
 /* Matrix index/slice functions */
-void* get_matrix(const matrix_t*, const int, const int);
-void set_matrix(matrix_t*, const int, const int, const void*);
-matrix_t* slice_matrix(const matrix_t*, const slice_t*, const slice_t*);
-void set_slice_matrix(matrix_t*, const slice_t*, const slice_t*, const matrix_t*);
+void* _get_matrix(const matrix_t*, const int, const int);
+void _set_matrix(matrix_t*, const int, const int, const void*);
+matrix_t* _slice_matrix(const matrix_t*, const slice_t*, const slice_t*);
+void _set_slice_matrix(matrix_t*, const slice_t*, const slice_t*, const matrix_t*);
 matrix_t* _insert_matrix(const matrix_t*, const int, const matrix_t*);
 matrix_t* _delete_matrix(const matrix_t*, const int);
 matrix_t* _append_matrix(const matrix_t*, const matrix_t*);
 
 /* Binary operations */
-int iexp(const int, const int);
-double fexp(const double, const double);
-matrix_t* matmult(const matrix_t*, const matrix_t*);
-matrix_t* mat_binop(const matrix_t*, const enum mat_op, const matrix_t*);
+int _iexp(const int, const int);
+double _fexp(const double, const double);
+matrix_t* _matmult(const matrix_t*, const matrix_t*);
+matrix_t* _mat_binop(const matrix_t*, const enum mat_op, const matrix_t*);
 
 /* Miscellaneous helpers/built-ins */
-void init_array(array_t*, const void*);
-void init_matrix(matrix_t*);
-int length(const array_t*);
-int rows(const matrix_t*);
-int cols(const matrix_t*);
+void _init_array(array_t*, const void*);
+void _init_matrix(matrix_t*);
+int _length(const array_t*);
+int _rows(const matrix_t*);
+int _cols(const matrix_t*);
 int _float_to_int(const double);
 double _int_to_float(const int);
 matrix_t* _flip_matrix_type(const matrix_t*);
-void die(const char*);
-void check(const bool, const char*);
+void _die(const char*);
+void _check(const bool, const char*);

--- a/parser.mly
+++ b/parser.mly
@@ -182,19 +182,19 @@ postfix_expr:
   | postfix_expr LBRACKET index RBRACKET
                               {
                                 match $3 with
-                                    Index _ -> Index_Expr(Sgl_Index($1, $3))
+                                  | Index _ -> Index_Expr(Sgl_Index($1, $3))
                                   | Slice _ -> Slice_Expr(Sgl_Slice($1, $3))
                               }
   | postfix_expr LBRACKET index COMMA index RBRACKET
                               {
                                 match ($3, $5) with
-                                    (Index _, Index _) ->
+                                  | Index _, Index _ ->
                                       Index_Expr(Dbl_Index($1, $3, $5))
-                                  | (Slice _, Index _) ->
+                                  | Slice _, Index _ ->
                                       Slice_Expr(Dbl_Slice($1, $3, index_to_slice($5)))
-                                  | (Index _, Slice _) ->
+                                  | Index _, Slice _ ->
                                       Slice_Expr(Dbl_Slice($1, index_to_slice($3), $5))
-                                  | (Slice _, Slice _) ->
+                                  | Slice _, Slice _ ->
                                       Slice_Expr(Dbl_Slice($1, $3, $5))
                               }
   /* Function Call */

--- a/parser.mly
+++ b/parser.mly
@@ -211,33 +211,33 @@ expr:
     prefix_expr              { $1 }
 
   /* Binary ops */
-  | expr PLUS   expr         { Binop($1, Add, $3) }
-  | expr MINUS  expr         { Binop($1, Sub, $3) }
-  | expr TIMES  expr         { Binop($1, Mult, $3) }
-  | expr DIVIDE expr         { Binop($1, Div, $3) }
-  | expr MATTIMES expr       { Binop($1, MatMult, $3) }
-  | expr MOD expr            { Binop($1, Mod, $3) }
-  | expr EXP expr            { Binop($1, Exp, $3) }
-  | expr EQ     expr         { Binop($1, Equal, $3) }
-  | expr NEQ    expr         { Binop($1, Neq, $3) }
-  | expr LANGLE expr         { Binop($1, Less, $3) }
-  | expr LEQ    expr         { Binop($1, Leq, $3) }
-  | expr RANGLE expr         { Binop($1, Greater, $3) }
-  | expr GEQ    expr         { Binop($1, Geq, $3) }
-  | expr AND    expr         { Binop($1, And, $3) }
-  | expr OR     expr         { Binop($1, Or, $3) }
+  | expr PLUS   expr         { Binop($1, Add, $3, false) }
+  | expr MINUS  expr         { Binop($1, Sub, $3, false) }
+  | expr TIMES  expr         { Binop($1, Mult, $3, false) }
+  | expr DIVIDE expr         { Binop($1, Div, $3, false) }
+  | expr MATTIMES expr       { Binop($1, MatMult, $3, false) }
+  | expr MOD expr            { Binop($1, Mod, $3, false) }
+  | expr EXP expr            { Binop($1, Exp, $3, false) }
+  | expr EQ     expr         { Binop($1, Equal, $3, false) }
+  | expr NEQ    expr         { Binop($1, Neq, $3, false) }
+  | expr LANGLE expr         { Binop($1, Less, $3, false) }
+  | expr LEQ    expr         { Binop($1, Leq, $3, false) }
+  | expr RANGLE expr         { Binop($1, Greater, $3, false) }
+  | expr GEQ    expr         { Binop($1, Geq, $3, false) }
+  | expr AND    expr         { Binop($1, And, $3, false) }
+  | expr OR     expr         { Binop($1, Or, $3, false) }
 
   /* Assignment ops */
   | expr ASSIGN expr         { Assign($1, $3) }
-  | expr PLUSASSIGN expr     { Assign($1, Binop($1, Add, $3)) }
-  | expr MINUSASSIGN expr    { Assign($1, Binop($1, Sub, $3)) }
-  | expr TIMESASSIGN expr    { Assign($1, Binop($1, Mult, $3)) }
-  | expr DIVIDEASSIGN expr   { Assign($1, Binop($1, Div, $3)) }
-  | expr MATTIMESASSIGN expr { Assign($1, Binop($1, MatMult, $3)) }
-  | expr MODASSIGN expr      { Assign($1, Binop($1, Mod, $3)) }
-  | expr EXPASSIGN expr      { Assign($1, Binop($1, Exp, $3)) }
-  | expr INC                 { Assign($1, Binop($1, Add, One)) }
-  | expr DEC                 { Assign($1, Binop($1, Sub, One)) }
+  | expr PLUSASSIGN expr     { Assign($1, Binop($1, Add, $3, true)) }
+  | expr MINUSASSIGN expr    { Assign($1, Binop($1, Sub, $3, true)) }
+  | expr TIMESASSIGN expr    { Assign($1, Binop($1, Mult, $3, true)) }
+  | expr DIVIDEASSIGN expr   { Assign($1, Binop($1, Div, $3, true)) }
+  | expr MATTIMESASSIGN expr { Assign($1, Binop($1, MatMult, $3, true)) }
+  | expr MODASSIGN expr      { Assign($1, Binop($1, Mod, $3, true)) }
+  | expr EXPASSIGN expr      { Assign($1, Binop($1, Exp, $3, true)) }
+  | expr INC                 { Assign($1, Binop($1, Add, One, true)) }
+  | expr DEC                 { Assign($1, Binop($1, Sub, One, true)) }
   /* Semantics: check that only IDs/index exprs can be assigned values */
 
 index:

--- a/sast.ml
+++ b/sast.ml
@@ -15,7 +15,8 @@ and sx =
   | SEmpty_Matrix of typ * sexpr * sexpr
   | SIndex_Expr of sindex_expr
   | SSlice_Expr of sslice_expr
-  | SBinop of sexpr * op * sexpr
+  (* See ast.ml for explanation of the bool field *)
+  | SBinop of sexpr * op * sexpr * bool
   | SUnop of uop * sexpr
   | SAssign of sexpr * sexpr
   | SCall of sexpr * sexpr list
@@ -95,7 +96,7 @@ let rec string_of_sexpr (t, e) =
         string_of_sexpr r ^ " x " ^ string_of_sexpr c ^ "]"
     | SIndex_Expr e -> string_of_sindex_expr e
     | SSlice_Expr e -> string_of_sslice_expr e
-    | SBinop(e1, o, e2) ->
+    | SBinop(e1, o, e2, _) ->
         string_of_sexpr e1 ^ " " ^ string_of_op o ^ " " ^ string_of_sexpr e2
     | SUnop(o, e) -> string_of_uop o ^ string_of_sexpr e
     | SAssign(e1, e2) -> string_of_sexpr e1 ^ " = " ^ string_of_sexpr e2

--- a/sast.ml
+++ b/sast.ml
@@ -107,9 +107,9 @@ let rec string_of_sexpr (t, e) =
   ) ^ ")"
 
 let string_of_svdecl (kw, t, id, sexpr) = match t, sexpr with
-  | (Exc, (_, SNoexpr)) -> string_of_decl_kw kw ^ " " ^ id ^ ";\n"
-  | (_, (_, SNoexpr)) -> string_of_decl_kw kw ^ " " ^ string_of_typ t ^ " " ^ id ^ ";\n"
-  | (_, _) -> string_of_decl_kw kw ^ " " ^ string_of_typ t ^ " " ^ id ^ " = " ^
+  | Exc, (_, SNoexpr) -> string_of_decl_kw kw ^ " " ^ id ^ ";\n"
+  | _, (_, SNoexpr) -> string_of_decl_kw kw ^ " " ^ string_of_typ t ^ " " ^ id ^ ";\n"
+  | _ -> string_of_decl_kw kw ^ " " ^ string_of_typ t ^ " " ^ id ^ " = " ^
       string_of_sexpr sexpr ^ ";\n"
 
 let rec string_of_sstmt = function

--- a/semant.ml
+++ b/semant.ml
@@ -667,15 +667,21 @@ let check (globals, functions) =
         )
     | Unop(op, e) ->
         let env, (t, e') = check_expr env e in
-        let ty =
+        let ty, ex' =
           match op with
-          | Neg when t = Int || t = Float -> t
-          | Not when t = Bool -> Bool
+          | Neg when t = Int || t = Float -> (t, SUnop(op, (t, e')))
+          | Neg when t = Matrix Int || t = Matrix Float ->
+              let neg_one =
+                if typ_of_container t = Int then (Int, SInt_Lit (-1))
+                else (Float, SFloat_Lit "-1.")
+              in
+              (t, SBinop(neg_one, Mult, (t, e')))
+          | Not when t = Bool -> (t, SUnop(op, (t, e')))
           | _ -> make_err ("illegal unary operator " ^
               string_of_uop op ^ string_of_typ t ^
               " in " ^ expr_s)
         in
-        (env, (ty, SUnop(op, (t, e'))))
+        (env, (ty, ex'))
     | Binop(e1, op, e2) ->
         let env, (t1, e1') = check_expr env e1 in
         let env, (t2, e2') =

--- a/semant.ml
+++ b/semant.ml
@@ -184,11 +184,11 @@ let check (globals, functions) =
       else
         let rec typ_contains_class typ typ_class =
           match typ, typ_class with
-          | (Matrix _, "matrix") -> true
-          | (Func(_, _), "function") -> true
-          | (Array _, "array") -> true
-          | (Array t, _) -> typ_contains_class t typ_class
-          | (_, _) -> string_of_typ typ = typ_class
+          | Matrix _, "matrix" -> true
+          | Func(_, _), "function" -> true
+          | Array _, "array" -> true
+          | Array t, _ -> typ_contains_class t typ_class
+          | _ -> string_of_typ typ = typ_class
         in
         let env =
           { env with
@@ -226,7 +226,7 @@ let check (globals, functions) =
     else
       let is_builtin_assign lvaluet rvaluet =
         match lvaluet, rvaluet with
-        | (Func(_, _), BuiltInFunc) -> true
+        | Func(_, _), BuiltInFunc -> true
         | _ -> false
       in
       if is_builtin_assign lvaluet rvaluet then
@@ -695,17 +695,17 @@ let check (globals, functions) =
           * will also be a matrix due to broadcasting *)
         let env, res_is_matrix =
           match t1, t2 with
-          | (Matrix _, Matrix _) -> (add_helper_use env "mat_binop", true)
+          | Matrix _, Matrix _ -> (add_helper_use env "mat_binop", true)
           (* In this case, this means we perform broadcasting; check_arith_operand
            * will ensure that the base types are equal. We need to add _free_matrix
            * as a built-in use; while the user program won't directly call it,
            * we will be generating a temporary matrix for the scalar and therefore
            * need to free it directly after computation, so the generated LLVM will be
            * calling it. *)
-          | (Matrix t, _) | (_, Matrix t) ->
+          | Matrix t, _ | _, Matrix t ->
               let env, _ = get_native_of_builtin env "free" [Matrix t] in
               (add_helper_use env "mat_binop", true)
-          | (_, _) -> (env, false)
+          | _ -> (env, false)
         in
         (* Determine expression type based on operator and operand types *)
         let env, ty =

--- a/stdlib.neo
+++ b/stdlib.neo
@@ -5,13 +5,13 @@ void check(bool cond, string err) {
 }
 
 matrix<int> itranspose(matrix<int> mat) {
-    var int r = rows(mat);
-    var int c = cols(mat);
+    auto r = rows(mat);
+    auto c = cols(mat);
 
     create matrix<int> res[c][r];
 
-    for (var int i = 0; i < c; i++) {
-        for (var int j = 0; j < r; j++) {
+    for (auto i = 0; i < c; i++) {
+        for (auto j = 0; j < r; j++) {
             res[i, j] = mat[j, i];
         }
     }
@@ -20,16 +20,194 @@ matrix<int> itranspose(matrix<int> mat) {
 }
 
 matrix<float> ftranspose(matrix<float> mat) {
-    var int r = rows(mat);
-    var int c = cols(mat);
+    auto r = rows(mat);
+    auto c = cols(mat);
 
     create matrix<float> res[c][r];
 
-    for (var int i = 0; i < c; i++) {
-        for (var int j = 0; j < r; j++) {
+    for (auto i = 0; i < c; i++) {
+        for (auto j = 0; j < r; j++) {
             res[i, j] = mat[j, i];
         }
     }
 
+    return res;
+}
+
+float fabs(float x) {
+    if (x >= 0.) {
+        return x;
+    } else {
+        return -x;
+    }
+}
+
+void fswap_rows(matrix<float> m, int i1, int i2) {
+    for (auto j = 0; j < cols(m); j++) {
+        auto temp = m[i1, j];
+        m[i1, j] = m[i2, j];
+        m[i2, j] = temp;
+    }
+}
+
+matrix<float> feye(int n) {
+    create matrix<float> m[n][n];
+    for (auto i = 0; i < n; i++) {
+        m[i, i] = 1.;
+    }
+    return m;
+}
+
+array<matrix<float>> pivot(matrix<float> m) {
+    /* Check m is square */
+    check(rows(m) == cols(m), "Dimension error: attempted to get pivot permutation matrix of non-square matrix");
+
+    auto n = rows(m);
+    auto sign = 1.;
+
+    auto res = feye(n);
+
+    for (auto j = 0; j < n; j++) {
+        auto max_row_i = j;
+        for (auto i = j; i < n; i++) {
+            if (fabs(m[i, j]) > fabs(m[max_row_i, j])) {
+                max_row_i = i;
+            }
+        }
+        if (j != max_row_i) {
+            sign *= -1.;
+            fswap_rows(res, max_row_i, j);
+        }
+    }
+
+    return {| res, [[sign]] |};
+}
+
+array<matrix<float>> lu_factor(matrix<float> m) {
+    /* Check m is square */
+    check(rows(m) == cols(m), "Dimension error: attempted to perform LU decomposition on a non-square matrix");
+
+    auto n = rows(m);
+    auto pivot_res = pivot(m);
+    auto pivot = pivot_res[0];
+    auto pivot_sign = pivot_res[1];
+    free(pivot_res);
+
+    auto pm = pivot @ m;
+    auto l = feye(n);
+    create matrix<float> u[n][n];
+    for (auto j = 0; j < n; j++) {
+        for (auto i = 0; i <= j; i++) {
+            auto sum = 0.;
+            for (auto k = 0; k < i; k++) {
+                sum += l[i, k] * u[k, j];
+            }
+            u[i, j] = pm[i, j] - sum;
+        }
+
+        for (auto i = j; i < n; i++) {
+            auto sum = 0.;
+            for (auto k = 0; k < j; k++) {
+                sum += l[i, k] * u[k, j];
+            }
+            l[i, j] = (pm[i, j] - sum) / u[j, j];
+        }
+    }
+
+    free(pm);
+    return {| pivot, pivot_sign, l, u |};
+}
+
+matrix<float> lu_solve(matrix<float> l, matrix<float> u, matrix<float> b) {
+    /* Check l and u are square */
+    check(rows(l) == cols(l), "Dimension error: lu_solve requires l to be square");
+    check(rows(u) == cols(u), "Dimension error: lu_solve requires u to be square");
+    check(rows(l) == rows(u), "Dimension error: lu_solve requires l and u to have the same rows");
+    check(cols(l) == cols(u), "Dimension error: lu_solve requires l and u to have the same cols");
+    /* Check that b has compatible dimensions */
+    check(rows(l) == rows(b), "Dimension error: lu_solve requires l and b to have the same rows");
+
+    auto n = rows(l);
+
+    /* We first solve ly = b */
+    create matrix<float> y[n][cols(b)];
+    for (auto i = 0; i < n; i++) {
+        create matrix<float> sum[1][cols(b)];
+        for (auto j = 0; j < i; j++) {
+            sum += l[i, j] * y[j];
+        }
+        y[i] = b[i] - sum;
+        free(sum);
+    }
+
+    /* Next, we solve ux = y */
+    create matrix<float> x[n][cols(y)];
+    for (auto i = n - 1; i >= 0; i--) {
+        create matrix<float> sum[1][cols(y)];
+        for (auto j = n - 1; j > i; j--) {
+            sum += u[i, j] * x[j];
+        }
+        x[i] = (y[i] - sum) / u[i, i];
+        free(sum);
+    }
+
+    free(y);
+    return x;
+}
+
+float det(matrix<float> m) {
+    /* Check m is square */
+    check(rows(m) == cols(m), "Dimension error: attempted to get determinant of non-square matrix");
+
+    auto n = rows(m);
+
+    auto lu_result = lu_factor(m);
+    auto pivot = lu_result[0];
+    auto pivot_sign = lu_result[1];
+    auto l = lu_result[2];
+    auto u = lu_result[3];
+
+    auto l_det = 1.;
+    auto u_det = 1.;
+
+    for (auto i = 0; i < n; i++) {
+        l_det *= l[i, i];
+        u_det *= u[i, i];
+    }
+
+    auto det = pivot_sign[0, 0] * l_det * u_det;
+
+    deep_free(lu_result);
+    return det;
+}
+
+matrix<float> inv(matrix<float> m) {
+    /* Check m is square */
+    check(rows(m) == cols(m), "Dimension error: attempted to invert non-square matrix");
+
+    auto n = rows(m);
+
+    auto lu_result = lu_factor(m);
+    auto pivot = lu_result[0];
+    auto pivot_sign = lu_result[1];
+    auto l = lu_result[2];
+    auto u = lu_result[3];
+
+    auto l_det = 1.;
+    auto u_det = 1.;
+
+    for (auto i = 0; i < n; i++) {
+        l_det *= l[i, i];
+        u_det *= u[i, i];
+    }
+
+    check(l_det * u_det != 0., "Singular matrix error: attempted to invert singular matrix");
+
+    auto id = feye(n);
+    auto res = lu_solve(l, u, id);
+    res @= pivot;
+
+    deep_free(lu_result);
+    free(id);
     return res;
 }

--- a/test/test-mat-arith.neo
+++ b/test/test-mat-arith.neo
@@ -2,7 +2,7 @@ void main() {
     create matrix<int> a = [[1, 2], [3, 4]];
     create matrix<int> b = [[1, 2], [3, 4]];
     println(a + b);
-    println(2 * a);
+    println(-2 * -a);
     create matrix<float> c = [[1., 2.], [3., 4.]];
     println(0.5 ^ c);
     println(c <= 2.);


### PR DESCRIPTION
- [x] Implemented negation of matrices (`semant` replaces this with a binop)
- [x] Added some basic support for memory management of unreachable matrices (like the use of lits/unreachable assign values, slices, etc.) in binary operations
- [x] Streamlined name-mangling by using regexes instead of passing arg types to codegen
- [x] Some more formatting
- [x] Implemented `det` and `inv` in the standard library, and implemented some other useful functions too (like LU decomposition, for example)